### PR TITLE
build: add textlintplugin keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "keywords": [
         "lint",
         "textlint",
+        "textlintplugin",
         "plugin",
         "po"
     ],


### PR DESCRIPTION
follow the official convention introduced at
https://textlint.github.io/docs/plugin.html#publishing